### PR TITLE
Fix linux makefile and GLFW usage on linux

### DIFF
--- a/Makefile.linux
+++ b/Makefile.linux
@@ -1,13 +1,13 @@
 # Linux version
 
 CC = clang++
-CFLAGS = -I./include -I./glfw -I./glfw/x11
+CFLAGS = $(shell pkg-config --cflags glu) $(shell pkg-config --cflags gl)
 CPPFLAGS = -std=c++11
 # Disabled
 # -stdlib=libc++
-LFLAGS = -lGL -lGLU
+LFLAGS = $(shell pkg-config --libs glu) $(shell pkg-config --libs gl) $(shell pkg-config --libs x11) $(shell pkg-config --libs xxf86vm) $(shell pkg-config --libs libglfw) -pthread
 
-OBJS = ./src/*.cpp ./src/*/*.cpp ./src/*/*/*.cpp ./lib/libglfw.a
+OBJS = ./src/*.cpp ./src/*/*.cpp ./src/*/*/*.cpp
 
 # Rule for Conception
 Conception: $(OBJS) Makefile.linux

--- a/src/Input/InputManager.cpp
+++ b/src/Input/InputManager.cpp
@@ -277,7 +277,7 @@ void GLFWCALL InputManager::ProcessMousePos(int MousePositionX, int MousePositio
 	// TODO: Should I even treat it as a pointer device? Maybe not.
 }
 
-void GLFWCALL InputManager::ProcessMouseWheel(int MouseWheelPosition, int MouseWheel2Position)
+void GLFWCALL InputManager::ProcessMouseWheel(int MouseWheelPosition)
 {
 	{
 		InputEvent InputEvent;
@@ -285,7 +285,6 @@ void GLFWCALL InputManager::ProcessMouseWheel(int MouseWheelPosition, int MouseW
 		InputEvent.m_DeviceId = 0;
 		InputEvent.m_InputId = 2;
 		InputEvent.m_Axes.push_back(Input::AxisState(MouseWheelPosition, 0));
-		InputEvent.m_Axes.push_back(Input::AxisState(MouseWheel2Position, 0));
 		InputEvent.m_Pointer = m_pInstance->m_MousePointer.get();
 
 		InputEvent.m_Pointer->ProcessEvent(InputEvent);

--- a/src/Input/InputManager.h
+++ b/src/Input/InputManager.h
@@ -34,7 +34,7 @@ public:
 	static void GLFWCALL ProcessChar(int Character, int Action);
 	static void GLFWCALL ProcessMouseButton(int MouseButton, int Action);
 	static void GLFWCALL ProcessMousePos(int MousePositionX, int MousePositionY);
-	static void GLFWCALL ProcessMouseWheel(int MouseWheelPosition, int MouseWheel2Position);
+	static void GLFWCALL ProcessMouseWheel(int MouseWheelPosition);
 #ifdef _GLFW_DMITRI_WINDOWS_TOUCH_ENABLED
 	static void GLFWCALL ProcessTouch(int TouchButton, int Action, int TouchPositionX, int TouchPositionY);		// Action: 0 = Down, 1 = Move, 2 = Up
 #endif // _GLFW_DMITRI_WINDOWS_TOUCH_ENABLED


### PR DESCRIPTION
This pull request fixes compilation on a (recent) debian/ubuntu system with GLFW and pkg-config

There appears to be incompatibility with the InputManager::ProcessMouseWheel that takes different arguments, i am not sure wether this is intended or not, i guess if the version changes based on operating system we can ifdef it. I edited the function to make it comply with the required signature, but i am not at all sure this is "safe", since i do not know glfw.
Any comments are welcome, thanks for developing this!