### PR TITLE
fixed from PVS-Studio:

### DIFF
--- a/glfw/tga.c
+++ b/glfw/tga.c
@@ -306,8 +306,7 @@ int _glfwReadTGA( _GLFWstream *s, GLFWimage *img, int flags )
         swapy = 0;
         break;
     }
-    if( (swapy && !(flags & GLFW_ORIGIN_UL_BIT)) ||
-        (!swapy && (flags & GLFW_ORIGIN_UL_BIT)) )
+    if( swapy != (flags & GLFW_ORIGIN_UL_BIT))
     {
         src = pix;
         dst = &pix[ (h.height-1)*h.width*bpp ];


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio. Warnings:

[V728](https://www.viva64.com/en/w/v728/) An excessive check can be simplified. The '(A && !B) || (!A && B)' expression is equivalent to the 'bool(A) != bool(B)' expression. tga.c 309